### PR TITLE
Remove need to explicitly fine-tune resolution for individual plugins

### DIFF
--- a/gradle-plugin-analyzer/plugin/src/main/kotlin/org.gradlex.plugins.analyzer.plugin.gradle.kts
+++ b/gradle-plugin-analyzer/plugin/src/main/kotlin/org.gradlex.plugins.analyzer.plugin.gradle.kts
@@ -1,7 +1,5 @@
 import com.google.common.collect.MultimapBuilder
 import org.gradle.api.internal.lambdas.SerializableLambdas
-import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.plugins.jvm.internal.JvmPluginServices
 import org.gradle.internal.Actions
 import org.gradlex.plugins.analyzer.DefaultAnalyzer
 import org.gradlex.plugins.analyzer.analysis.TaskImplementationDoesNotExtendDefaultTask
@@ -18,23 +16,22 @@ import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import kotlin.streams.toList
 
+plugins {
+    // Required since we are resolving JVM artifacts
+    id("jvm-ecosystem")
+}
+
 open class AnalyzedPlugin(val pluginId: String) : Comparable<AnalyzedPlugin>, Named, Serializable {
 
     var artifact: String? = null
 
     var sourceUrl: String? = null
 
-    internal var shadowed = false
-
     internal var configurator: Action<in Configuration> = Actions.doNothing()
 
     override fun getName() = pluginId
     fun configuration(configurator: SerializableLambdas.SerializableAction<in Configuration>) {
         this.configurator = configurator
-    }
-
-    fun shadowed() {
-        shadowed = true
     }
 
     override fun compareTo(other: AnalyzedPlugin) = pluginId.compareTo(other.pluginId)
@@ -216,14 +213,11 @@ afterEvaluate {
     // Must run in afterEvaluate to get the actual configuration of the elements in the container; all() triggers too early
     analyzedPlugins.asMap().forEach { info, plugins ->
         val simplifiedName = info.artifact.replace(':', '_').replace('.', '_')
+
         val config = configurations.create("conf_$simplifiedName")
-        // Magic by Justin
-        (project as ProjectInternal).services.get(JvmPluginServices::class.java).configureAsRuntimeClasspath(config)
-        if (plugins.any { it.shadowed }) {
-            config.attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.SHADOWED))
-        }
+        configureRequestAttributes(config)
         plugins.forEach { it.configurator.execute(config) }
-        dependencies.add(config.name, info.artifact)
+        config.dependencies.add(dependencies.create(info.artifact))
 
         val task = tasks.register<PluginAnalyzerTask>("analyze_$simplifiedName") {
             pluginIds = plugins.map { it.pluginId }
@@ -237,5 +231,25 @@ afterEvaluate {
         analyzePluginsTask.configure {
             inputReports.from(task.flatMap { it.reportFile })
         }
+    }
+}
+
+/**
+ * Use the same request attribute that Gradle will use to resolve the plugin classpath, as defined by:
+ * [Link](https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java#L52-L67)
+ *
+ * Note, that by setting the `TargetJvmVersion` attribute, we restrict this build to be run on a Java version
+ * greater than or equal to the maximum target Java version of all plugins that we resolve.
+ * In this case, setting that attribute requires this build to be executed on Java 17 at the minimum.
+ * We _could_ remove this attribute, in which case, the variant with the highest Java version will be selected.
+ */
+fun configureRequestAttributes(config: Configuration) {
+    config.attributes {
+        attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
+        attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, Category.LIBRARY))
+        attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements::class.java, LibraryElements.JAR))
+        attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling::class.java, Bundling.EXTERNAL))
+        attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersion.toInt())
+        attributes.attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, objects.named(GradlePluginApiVersion::class.java, GradleVersion.current().version))
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/runner/build.gradle.kts
+++ b/runner/build.gradle.kts
@@ -14,9 +14,9 @@ pluginAnalyzer {
     plugin("com.adarshr.test-logger")
     plugin("com.atlassian.performance.tools.gradle-release")
     plugin("com.avast.gradle.docker-compose")
-    plugin("com.bmuschko.docker-java-application") { shadowed() }
-    plugin("com.bmuschko.docker-remote-api") { shadowed() }
-    plugin("com.bmuschko.docker-spring-boot-application") { shadowed() }
+    plugin("com.bmuschko.docker-java-application")
+    plugin("com.bmuschko.docker-remote-api")
+    plugin("com.bmuschko.docker-spring-boot-application")
     plugin("com.diffplug.configuration-cache-for-platform-specific-build")
     plugin("com.diffplug.eclipse.excludebuildfolder")
     plugin("com.diffplug.eclipse.mavencentral")
@@ -43,62 +43,27 @@ pluginAnalyzer {
     plugin("com.github.node-gradle.node")
     plugin("com.github.spotbugs")
     plugin("com.github.spotbugs-base")
-    plugin("com.google.cloud.tools.jib") {
-        configuration {
-            // For some reason these dependencies were not found
-            exclude("com.fasterxml.jackson.core", "jackson-databind")
-            exclude("com.fasterxml.jackson.datatype", "jackson-datatype-jsr310")
-        }
-    }
+    plugin("com.google.cloud.tools.jib")
     plugin("com.google.protobuf")
-    plugin("com.gorylenko.gradle-git-properties") { shadowed() }
+    plugin("com.gorylenko.gradle-git-properties")
     plugin("com.gradle.build-scan")
-    plugin("com.gradle.plugin-publish") { shadowed() }
+    plugin("com.gradle.plugin-publish")
     plugin("com.jfrog.artifactory")
     plugin("com.palantir.docker")
     plugin("com.palantir.docker-compose")
     plugin("com.palantir.docker-run")
     plugin("com.russianprussian.avast.gradle.docker-compose")
-    plugin("de.undercouch.download") { shadowed() }
+    plugin("de.undercouch.download")
     plugin("io.franzbecker.gradle-lombok")
     plugin("io.freefair.lombok")
     plugin("io.gitlab.arturbosch.detekt")
-    // TODO These both require shadowed and non-shadowed?? Suppressing the Docker plugin helps, though
-    plugin("io.micronaut.aot") {
-        configuration {
-            exclude("com.bmuschko", "gradle-docker-plugin")
-        }
-    }
-    plugin("io.micronaut.application") {
-        configuration {
-            exclude("com.bmuschko", "gradle-docker-plugin")
-        }
-    }
-    plugin("io.micronaut.docker") {
-        configuration {
-            exclude("com.bmuschko", "gradle-docker-plugin")
-        }
-    }
-    plugin("io.micronaut.graalvm") {
-        configuration {
-            exclude("com.bmuschko", "gradle-docker-plugin")
-        }
-    }
-    plugin("io.micronaut.library") {
-        configuration {
-            exclude("com.bmuschko", "gradle-docker-plugin")
-        }
-    }
-    plugin("io.micronaut.minimal.application") {
-        configuration {
-            exclude("com.bmuschko", "gradle-docker-plugin")
-        }
-    }
-    plugin("io.micronaut.minimal.library") {
-        configuration {
-            exclude("com.bmuschko", "gradle-docker-plugin")
-        }
-    }
+    plugin("io.micronaut.aot")
+    plugin("io.micronaut.application")
+    plugin("io.micronaut.docker")
+    plugin("io.micronaut.graalvm")
+    plugin("io.micronaut.library")
+    plugin("io.micronaut.minimal.application")
+    plugin("io.micronaut.minimal.library")
     plugin("io.qameta.allure")
     plugin("io.spring.dependency-management")
     plugin("nebula.info-basic")
@@ -119,7 +84,7 @@ pluginAnalyzer {
     plugin("org.gradle.kotlin.kotlin-dsl.base")
     plugin("org.gradle.kotlin.kotlin-dsl.compiler-settings")
     plugin("org.gradle.kotlin.kotlin-dsl.precompiled-script-plugins")
-    plugin("org.gradle.test-retry") { shadowed() }
+    plugin("org.gradle.test-retry")
     plugin("org.jetbrains.gradle.plugin.idea-ext")
     plugin("org.jetbrains.kotlin.android")
     plugin("org.jetbrains.kotlin.android.extensions")


### PR DESCRIPTION
By applying the `jvm-ecosystem` plugin and specifying the request attributes to be the same as the attributes that Gradle uses during normal plugin resolution, we avoid fine-tuning resolution for individual plugins.

As such, we can remove all usages of the 'configuration' DSL from the `:runner` project. We have also removed the 'shadowed' method from the DSL, as it is no longer required to be specified explicitly. In general, we should be able to remove the 'configuration' DSL block entirely, as it is no longer called by any of the currently analyzed plugins. We will likely not be needed for any other conventional plugin that is already resolvable by Gradle.