### PR TITLE
Avoid afterEvaluate

### DIFF
--- a/gradle-plugin-analyzer/plugin/src/main/kotlin/org.gradlex.plugins.analyzer.plugin.gradle.kts
+++ b/gradle-plugin-analyzer/plugin/src/main/kotlin/org.gradlex.plugins.analyzer.plugin.gradle.kts
@@ -203,15 +203,14 @@ val analyzePluginsTask = tasks.register<PluginAnalysisCollectorTask>("analyzePlu
 val pluginAnalyzer = extensions.create<PluginAnalyzerExtension>("pluginAnalyzer")
 
 pluginAnalyzer.analyzedPlugins.all {
-    val analyzedPlugin = this
-    val simplifiedName = analyzedPlugin.pluginId.replace(':', '_').replace('.', '_')
+    val simplifiedName = pluginId.replace(':', '_').replace('.', '_')
 
     val config = configurations.create("conf_$simplifiedName")
     configureRequestAttributes(config)
 
-    val defaultCoordinates = analyzedPlugin.pluginId + ":" + analyzedPlugin.pluginId + ".gradle.plugin:latest.release"
+    val defaultCoordinates = "$pluginId:$pluginId.gradle.plugin:latest.release"
     config.dependencies.addLater(
-        analyzedPlugin.coordinates.orElse(defaultCoordinates).map { dependencyFactory.create(it) }
+        coordinates.orElse(defaultCoordinates).map { dependencyFactory.create(it) }
     )
 
     val analyzeTask = tasks.register<PluginAnalyzerTask>("analyze_$simplifiedName") {
@@ -220,8 +219,9 @@ pluginAnalyzer.analyzedPlugins.all {
         reportFile = project.layout.buildDirectory.file("plugin-analysis/plugins/report-${simplifiedName}.json")
     }
 
+    val analyzedId = pluginId
     val formatterTask = tasks.register<FormatReportTask>("format_$simplifiedName") {
-        pluginId = analyzedPlugin.pluginId
+        pluginId = analyzedId
         jsonReport = analyzeTask.flatMap { it.reportFile }
         markdownReport = project.layout.buildDirectory.file("plugin-analysis/plugins/report-${simplifiedName}.md")
     }

--- a/runner/build.gradle.kts
+++ b/runner/build.gradle.kts
@@ -111,13 +111,9 @@ pluginAnalyzer {
     plugin("org.springframework.boot")
 
     // From popular plugins – https://docs.google.com/spreadsheets/d/1p-soKHdFdYyrrmokHXg9ug03hK4VoU8oAo7g28Knels/
-    plugin("com.google.dagger") {
-        artifact = "com.google.dagger:hilt-android-gradle-plugin:2.47"
-    }
-    plugin("com.google.services") {
-        artifact = "com.google.gms:google-services:4.3.15"
-    }
+    plugin("com.google.dagger.hilt.android")
+    plugin("com.google.gms.google-services")
     plugin("com.guardsquare.proguard") {
-        artifact = "com.guardsquare:proguard-gradle:7.3.2"
+        coordinates = "com.guardsquare:proguard-gradle:7.3.2"
     }
 }


### PR DESCRIPTION
By declaring the plugin jar coordinates as a Provider, we can lazily add dependencies to the configuration and avoid evaulation order problems